### PR TITLE
Re-export @architect/functions from `/shared`

### DIFF
--- a/ts/http/get-login/index.ts
+++ b/ts/http/get-login/index.ts
@@ -1,6 +1,6 @@
-import arc from "@architect/functions";
-
+import { arc } from "../../shared/arc";
 import { buildUrl } from "../../shared/utils";
+
 import type { ApiRequest } from "../../../typings";
 
 const scopes = [

--- a/ts/shared/arc.ts
+++ b/ts/shared/arc.ts
@@ -1,0 +1,1 @@
+export * as arc from "@architect/functions";


### PR DESCRIPTION
The default behaviour is that `/shared` modules will be automatically included in `/http` modules that refer them, but node_modules` dependencies will not.

To include `node_modules` dependencies a lambda must include its own `package.json` and make a reference to them there... but then `/shared` modules will no longer be written to its local `node_modules` directory by default.

The default behaviour is much more convenient for the set-up I'm using to author in TS and write to `http`, so I'm seeing whether re-exporting from shared works on the opening `get-login` route.