### PR TITLE
Use a symlink inside local node_modules to import from @architect/shared

### DIFF
--- a/ts/http/get-login/index.ts
+++ b/ts/http/get-login/index.ts
@@ -1,7 +1,5 @@
-// import arc from "@architect/functions";
-
-import { arc } from "../../shared/arc";
-import { buildUrl } from "../../shared/utils";
+import arc from "@architect/functions";
+import { buildUrl } from "@architect/shared/utils";
 
 import type { ApiRequest } from "../../../typings";
 

--- a/ts/shared/arc.ts
+++ b/ts/shared/arc.ts
@@ -1,3 +1,0 @@
-// Force the inclusion of @architect/functions without needing to include 
-// per-Lambda package.json files
-export * as arc from "@architect/functions";

--- a/ts/shared/package.json
+++ b/ts/shared/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "beatportify-shared",
-  "dependencies": {
-    "@architect/functions": "latest"
-  }
-}


### PR DESCRIPTION
Channeling my inner Rich Harris here...

If this works, all lambdas under `/ts` will have a local `node_modules/@architect` directory containing a symlink to `shared` so that `@architect/shared` resolves at author time and in prod