### PR TITLE
Create virtual albums from playlists that are DJ mixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,7 @@ Navigate to [localhost:3333](http://localhost:3333)
 - [ ] Paging: Scroll-to-load on paged content
 - [ ] Album: Use CSS counter to display track numbers against names AND/OR create `albumIndex`?
 - [ ] Album: Don't repeat cover image per track
+- [ ] Album: Assume an album if all tracks within a playlist share the same album id
 
 #### Stretch
 - [ ] Use Spotify Connect to highlight playing track

--- a/ts/http/get-api-albums-000albumId/index.ts
+++ b/ts/http/get-api-albums-000albumId/index.ts
@@ -24,6 +24,9 @@ const getAlbumData: ApiRequest = async (req, headers) => {
     release_date: releaseDate,
   } = album;
 
+  console.log(JSON.stringify(album, null, 2));
+  
+
   // TODO: Relax `processTrack` requirements: Pick<{...required}>
   // TODO: Use CSS counter to display track numbers against names
   const albumTracks: any[] = [];
@@ -45,8 +48,6 @@ const getAlbumData: ApiRequest = async (req, headers) => {
   } catch (err) {
     console.log({ err });
   }
-
-  console.log({ tracks });
 
   return {
     id,


### PR DESCRIPTION
Some playlists are actually DJ mixes and should be considered as albums for the purposes of rendering the UI with a single non-repeated cover and compact, numbered tracks:

Examples:
- [Balkan Connection Mixed, Vol. 10 (DJ Mix)](https://lgagerxflc.execute-api.us-west-2.amazonaws.com/playlist/6GltABPpK1laFBIWFZ1dgQ)
- [Matter – Meanwhile 013 (DJ Mix)](https://lgagerxflc.execute-api.us-west-2.amazonaws.com/playlist/63KxCD818aUtCQR8V1MMLk)